### PR TITLE
Remove unused using directive in StateMachine.cs

### DIFF
--- a/Assets/_Project/Scripts/Systems/State Machine/StateMachine.cs
+++ b/Assets/_Project/Scripts/Systems/State Machine/StateMachine.cs
@@ -1,6 +1,5 @@
 using Systems.Input;
 using UnityEngine;
-using static UnityEditorInternal.VersionControl.ListControl;
 
 #region Core - StateMachine
 /// <summary>


### PR DESCRIPTION
Eliminated an unnecessary 'using static' directive from StateMachine.cs to clean up the code and improve maintainability.